### PR TITLE
Stick to phpcs 2.9.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,10 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 before_script:
-  - composer install --dev
+  - composer install
   - ./vendor/squizlabs/php_codesniffer/scripts/phpcs --version
   - mkdir -p vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/Symfony
   - cp -R Sniffs/ vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/Symfony/Sniffs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - 7.1
 
 before_script:
   - composer install --dev
@@ -14,5 +16,5 @@ before_script:
   - cp ruleset.xml vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/Symfony
 
 script:
-  - (cd vendor/squizlabs/php_codesniffer ; phpunit --filter Symfony_)
+  - (cd vendor/squizlabs/php_codesniffer ; ../../bin/phpunit --filter Symfony_)
   - ./vendor/squizlabs/php_codesniffer/scripts/phpcs Sniffs --standard=PHPCS --report=summary -np

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
 
 before_script:
   - composer install --dev
+  - ./vendor/squizlabs/php_codesniffer/scripts/phpcs --version
   - mkdir -p vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/Symfony
   - cp -R Sniffs/ vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/Symfony/Sniffs/
   - cp -R Tests/ vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/Symfony/Tests/

--- a/Sniffs/Formatting/ClassInstantiationSniff.php
+++ b/Sniffs/Formatting/ClassInstantiationSniff.php
@@ -60,6 +60,7 @@ class Symfony_Sniffs_Formatting_ClassInstantiationSniff implements PHP_CodeSniff
         $allowedTokens[] = T_NS_SEPARATOR;
         $allowedTokens[] = T_VARIABLE;
         $allowedTokens[] = T_STATIC;
+        $allowedTokens[] = T_SELF;
 
         $next = $phpcsFile->findNext($allowedTokens, ($stackPtr + 1), null, true);
 

--- a/Sniffs/Formatting/MethodVisibilityOrderSniff.php
+++ b/Sniffs/Formatting/MethodVisibilityOrderSniff.php
@@ -157,7 +157,7 @@ class Symfony_Sniffs_Formatting_MethodVisibilityOrderSniff
 
             if (false === in_array($visibility, $allowedVisibilities)) {
                 $phpcsFile->addError(
-                    'Methods must me ordered public, protect, private',
+                    'Methods must be ordered public, protect, private',
                     $stackPtr,
                     null,
                     'OrderMethodsByVisibility'

--- a/Tests/Commenting/FunctionCommentUnitTest.pass.inc
+++ b/Tests/Commenting/FunctionCommentUnitTest.pass.inc
@@ -46,7 +46,7 @@ class Pass
     /**
      * write stuff info
      *
-     * @param StuffInfo $info
+     * @param StuffInfo $info information
      */
     public function writeStuffInfo(StuffInfo $info)
     {

--- a/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/Tests/Commenting/FunctionCommentUnitTest.php
@@ -48,6 +48,7 @@ class Symfony_Tests_Commenting_FunctionCommentUnitTest extends AbstractSniffUnit
                     5  => 1,
                     10 => 1,
                     11 => 1,
+                    12 => 1,
                     20 => 1,
                     29 => 1,
                     37 => 1,

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "source": "https://github.com/xalopp/symfony-coding-standard"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "*"
+        "squizlabs/php_codesniffer": "2.9.x-dev",
+        "phpunit/phpunit": "~4.0"
     },
     "require": {
         "php": ">=5.4.0"

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "2.9.x-dev",
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "^4.0 || ^5.0"
     },
     "require": {
         "php": ">=5.4.0"


### PR DESCRIPTION
I propose to get this into the master branch and then abandon this project in order to use djoos/Symfony2-coding-standard as outlined in GH-9 in MO4 with PHPCS 3.x.